### PR TITLE
Readme fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,8 +62,7 @@ $generator = Builder::make()
                     ->serverSeed($serverSeed)
                     ->clientSeed($clientSeed)
                     ->nonce($nonce)
-                    ->min($min)
-                    ->max($max)
+                    ->range($min, $max)
                     ->build();
 ```
 ##### Default values


### PR DESCRIPTION
There is no `min()` and `max()` methods, `range()` only.